### PR TITLE
Add pricing module and basic Node test setup

### DIFF
--- a/assets/pricing.js
+++ b/assets/pricing.js
@@ -1,0 +1,24 @@
+import { DEVICE_CATALOG } from './devices.js';
+
+export const BUNDLE_BASE_INCLUDED = 3;
+export const BUNDLE_BASE_PRICE = 19.99;
+export const BUNDLE_EXTRA_PRICE = 5.99;
+
+export function computeTotals(items) {
+  let individualMonthly = 0;
+  let individualAnnual = 0;
+
+  for (const item of items) {
+    const dev = DEVICE_CATALOG.find(d => d.id === item.id);
+    if (!dev) continue;
+    individualMonthly += (dev.monthly || 0) * item.qty;
+    individualAnnual += (dev.annual || 0) * item.qty;
+  }
+
+  const totalQty = items.reduce((s, x) => s + x.qty, 0);
+  const extra = Math.max(0, totalQty - BUNDLE_BASE_INCLUDED);
+  const bundleMonthly = totalQty === 0 ? 0 : BUNDLE_BASE_PRICE + extra * BUNDLE_EXTRA_PRICE;
+  const bundleAnnual = bundleMonthly * 12;
+
+  return { individualMonthly, individualAnnual, bundleMonthly, bundleAnnual, totalQty, extra };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "carecompare",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/pricing.test.js
+++ b/tests/pricing.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeTotals, BUNDLE_BASE_PRICE, BUNDLE_EXTRA_PRICE } from '../assets/pricing.js';
+
+// Helper to round to cents for consistent comparisons
+const cents = (n) => Math.round(n * 100) / 100;
+
+test('computes totals under bundle limit', () => {
+  const items = [
+    { id: 'iphone-16', qty: 1 },
+    { id: 'macbook-air-13', qty: 1 },
+  ];
+  const totals = computeTotals(items);
+  assert.equal(cents(totals.individualMonthly), cents(11.99 + 6.99));
+  assert.equal(cents(totals.individualAnnual), cents(119.99 + 69.99));
+  assert.equal(totals.totalQty, 2);
+  assert.equal(totals.extra, 0);
+  assert.equal(cents(totals.bundleMonthly), cents(BUNDLE_BASE_PRICE));
+});
+
+test('computes bundle extras above included amount', () => {
+  const items = [
+    { id: 'iphone-16', qty: 4 },
+  ];
+  const totals = computeTotals(items);
+  assert.equal(totals.totalQty, 4);
+  assert.equal(totals.extra, 1);
+  assert.equal(cents(totals.bundleMonthly), cents(BUNDLE_BASE_PRICE + BUNDLE_EXTRA_PRICE));
+});


### PR DESCRIPTION
## Summary
- extract bundle pricing constants and totals logic into a dedicated module
- add basic Node-based unit tests for computeTotals
- provide package.json with a test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b756f98ea483239e6966c047246d65